### PR TITLE
Bug | Resolve delegate return null

### DIFF
--- a/src/API/Loggy.Api/README.md
+++ b/src/API/Loggy.Api/README.md
@@ -1,0 +1,21 @@
+## Loggy.Api
+
+### Sample queries
+
+Query: 
+     
+	 {
+       subQuery {
+         subQueryName
+       }
+     }
+
+Response:
+
+	{
+	  "data": {
+		"subQuery": {
+		  "subQueryName": "Some string value"
+		}
+	  }
+	}

--- a/src/API/Loggy.Api/Startup.cs
+++ b/src/API/Loggy.Api/Startup.cs
@@ -33,8 +33,9 @@ namespace Loggy.Api
 			services.AddSingleton<RootQuery>();
 			services.AddSingleton<MySubQuery>();
 			services.AddSingleton<LogEntriesQuery>();
+            services.AddSingleton<MySubObjectGraphType>();
 
-			var serviceProvider = services.BuildServiceProvider();
+            var serviceProvider = services.BuildServiceProvider();
 			services.AddSingleton<ISchema>(
 				new Schema.Schema(resolver: 
 					new FuncDependencyResolver(resolver: type => serviceProvider.GetService(type))));


### PR DESCRIPTION
Added singleton registration for MySubObjectGraphType
Added README.md to Loggy.Api with samples

Not 100% sure this fixes the issue, I just kinda jumped in and noticed that adding that registration in the Startup.cs caused the Graph API (Loggy.Api) to load without the error :) 